### PR TITLE
Bump ruby/setup-ruby from 1.120.0 to 1.161.0

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install node modules
       run: npm install
     - name: Set up Ruby
-      uses: ruby/setup-ruby@ece82769428359c077b5a5eaff268902a303c101
+      uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Set up Pages


### PR DESCRIPTION
**Bumps [ruby/setup-ruby](https://github.com/ruby/setup-ruby) from 1.120.0 to 1.161.0.
- [Release notes](https://github.com/ruby/setup-ruby/releases)
- [Commits](https://github.com/ruby/setup-ruby/compare/ece82769428359c077b5a5eaff268902a303c101...8575951200e472d5f2d95c625da0c7bec8217c42)

updated-dependencies:
- dependency-name: ruby/setup-ruby dependency-type: direct:production update-type: version-update:semver-minor ...

## Overview

<!--
One to two sentence description of the issue you are encountering or trying to solve.

Link to related issue. Type `closes #RELATED_ISSUE_NUMBER` to establish a link.
-->

## Questions

<!-- If relevant, write a list of questions that you would like to discuss related to the changes that you have made. -->

## Next steps

<!-- If incomplete, create a task list of items that are still being worked on within the Pull Request. -->

## Review

<!-- If complete, or ready for :eyes:, use @mentions for quick questions, specific feedback, and progress updates. -->
